### PR TITLE
added index.js for improved npm support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export * from "./dist/ZipLoader";
+export {default} from "./dist/ZipLoader";

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("./dist/ZipLoader");
+export * from "./dist/ZipLoader";

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/ZipLoader");

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "author": "Yomotsu",
   "license": "MIT",
-  "main": "dist/ZipLoader.js",
+  "main": "index.js",
   "repository": "yomotsu/ZipLoader",
   "jsnext:main": "dist/ZipLoader.module.js",
   "module": "dist/ZipLoader.module.js",


### PR DESCRIPTION
You can now import zip-loader easier in webpack, etc. like this:

`import * as ZipLoader from "zip-loader";`